### PR TITLE
Fix internal comparison exception and indexer handling (OSK-5)

### DIFF
--- a/src/OSK.Extensions.Object.DeepEquals.UnitTests/Helpers/ActionClass.cs
+++ b/src/OSK.Extensions.Object.DeepEquals.UnitTests/Helpers/ActionClass.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OSK.Extensions.Object.DeepEquals.UnitTests.Helpers
+{
+    public class ActionClass
+    {
+        public Func<MockStruct, Task> Action { get; set; }
+
+        public Action<MockStruct> Action2 { get; set; }
+
+        public int this[string name] => 1;
+    }
+}

--- a/src/OSK.Extensions.Object.DeepEquals.UnitTests/Internal/Comparers/EnumerableComparerTests.cs
+++ b/src/OSK.Extensions.Object.DeepEquals.UnitTests/Internal/Comparers/EnumerableComparerTests.cs
@@ -369,6 +369,84 @@ namespace OSK.Extensions.Object.DeepEquals.UnitTests.Internal.Comparers
             Assert.True(result);
         }
 
+        [Fact]
+        public void AreDeepEqual_Array_OrderNotEnforced_Unordered_DifferentObjectValues_ReturnsTrue()
+        {
+            // Arrange
+            var testA = new TestClass()
+            {
+                A = "Abc",
+                B = 123,
+                Ints = [4, 3, 2],
+                SubClass = new TestClass()
+                {
+                    A = "Cba",
+                    B = 3,
+                    Ints = null,
+                    SubClass = null
+                }
+            };
+            var testB = new TestClass()
+            {
+                A = "Noway",
+                B = 54321,
+                Ints = null,
+                SubClass = null
+            };
+            var cloneA = new TestClass()
+            {
+                A = "Abc",
+                B = 123,
+                Ints = [4, 3, 2],
+                SubClass = new TestClass()
+                {
+                    A = "Cba",
+                    B = 3,
+                    Ints = null,
+                    SubClass = null
+                }
+            };
+            var cloneB = new TestClass()
+            {
+                A = "Noway",
+                B = 54321,
+                Ints = null,
+                SubClass = null
+            };
+
+            var testSet1 = new[]
+            {
+                testA,
+                testB
+            };
+            var testSet2 = new[]
+            {
+                cloneB,
+                cloneA
+            };
+
+            var context = MockComparisonContext.SetupContext((_, objA, objB) =>
+            {
+                if (objA == testA || objA == cloneA)
+                {
+                    return objB == testA || objB == cloneA;
+                }
+                if (objA == testB || objA == cloneB)
+                {
+                    return objB == testB || objB == cloneB;
+                }
+
+                return false;
+            });
+
+            context.EnumerableComparisonOptions.EnforceEnumerableOrdering = false;
+
+            // Act
+            var result = _comparer.AreDeepEqual(context, testSet1, testSet2);
+
+            // Assert
+            Assert.True(result);
+        }
 
         #endregion
     }

--- a/src/OSK.Extensions.Object.DeepEquals.UnitTests/Internal/Comparers/GenericComparerTests.cs
+++ b/src/OSK.Extensions.Object.DeepEquals.UnitTests/Internal/Comparers/GenericComparerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Moq;
 using OSK.Extensions.Object.DeepEquals.Internal.Comparers;
 using OSK.Extensions.Object.DeepEquals.Ports;
@@ -77,6 +78,23 @@ namespace OSK.Extensions.Object.DeepEquals.UnitTests.Internal.Comparers
 
             // Assert
             Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void AreDeepEqual_ActionClass_ReturnsExpectedResult()
+        {
+            var actionClassA = new ActionClass()
+            {
+                Action = _ => Task.CompletedTask,
+                Action2 = _ => { }
+            };
+            var actionClassB = new ActionClass()
+            {
+                Action = _ => Task.CompletedTask,
+                Action2 = _ => { }
+            };
+
+            _comparer.AreDeepEqual(MockComparisonContext.SetupContext(), actionClassA, actionClassB);
         }
 
         #endregion

--- a/src/OSK.Extensions.Object.DeepEquals/Internal/Comparers/EnumerableComparer.cs
+++ b/src/OSK.Extensions.Object.DeepEquals/Internal/Comparers/EnumerableComparer.cs
@@ -67,6 +67,7 @@ namespace OSK.Extensions.Object.DeepEquals.Internal.Comparers
             var enumeratorB = b.GetEnumerator();
             var bSize = 0;
 
+            context.SuppressErrorThrow = true;
             while (enumeratorB.MoveNext())
             {
                 bSize++;
@@ -76,9 +77,11 @@ namespace OSK.Extensions.Object.DeepEquals.Internal.Comparers
                     continue;
                 }
 
+                context.SuppressErrorThrow = false;
                 return false;
             }
 
+            context.SuppressErrorThrow = false;
             return tempList.Count == bSize;
         }
 

--- a/src/OSK.Extensions.Object.DeepEquals/Internal/Services/PropertyCache.cs
+++ b/src/OSK.Extensions.Object.DeepEquals/Internal/Services/PropertyCache.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using OSK.Extensions.Object.DeepEquals.Models;
 using OSK.Extensions.Object.DeepEquals.Ports;
@@ -38,7 +39,7 @@ namespace OSK.Extensions.Object.DeepEquals.Internal.Services
             }
 
             var bindingFlags = GetPropertyBindings(propertyComparison);
-            propertyInfos = type.GetProperties(bindingFlags);
+            propertyInfos = type.GetProperties(bindingFlags).Except(type.GetDefaultMembers().OfType<PropertyInfo>());
 
             _propertyCache[type] = propertyInfos;
 

--- a/src/OSK.Extensions.Object.DeepEquals/Models/DeepComparisonContext.cs
+++ b/src/OSK.Extensions.Object.DeepEquals/Models/DeepComparisonContext.cs
@@ -23,6 +23,8 @@ namespace OSK.Extensions.Object.DeepEquals.Models
 
         public IDeepComparisonService DeepComparisonService { get; }
 
+        public bool SuppressErrorThrow { get; set; }
+
         #endregion
 
         #region Constructors
@@ -51,7 +53,7 @@ namespace OSK.Extensions.Object.DeepEquals.Models
 
         public void Fail(string message)
         {
-            if (ExecutionOptions.ThrowOnFailure)
+            if (!SuppressErrorThrow && ExecutionOptions.ThrowOnFailure)
             {
                 throw new DeepEqualityComparisonFailedException(message);
             }


### PR DESCRIPTION
Motivation
----
* Internal comparisons within the EnumerableComparer that fail for non-ordered comparisons can cause exceptions to be thrown when the unordered list is expected to not match initially
* Indexers can cause unexpected exceptions to be thrown due to the internal property validations

Modifications
----
* Ignore indexers during comparisons
* Ignore internal comparison failures during unordered list comparison
* Update UnitTests to reflect changes

Result
----
DeepEquals handles internal comparison and indexers without throwing unexpected errors

Fixes #5