### PR TITLE
Add DeepComparisonContext Scopes (OSK-7)

### DIFF
--- a/src/OSK.Extensions.Object.DeepEquals/Internal/Comparers/EnumerableComparer.cs
+++ b/src/OSK.Extensions.Object.DeepEquals/Internal/Comparers/EnumerableComparer.cs
@@ -67,12 +67,12 @@ namespace OSK.Extensions.Object.DeepEquals.Internal.Comparers
             var enumeratorB = b.GetEnumerator();
             var bSize = 0;
 
-            context.SuppressErrorThrow = true;
+            var scopedContext = context.CreateScopedContext();
             while (enumeratorB.MoveNext())
             {
                 bSize++;
 
-                if (tempList.Any(item => context.AreDeepEqual(item, enumeratorB.Current)))
+                if (tempList.Any(item => scopedContext.AreDeepEqual(item, enumeratorB.Current)))
                 {
                     continue;
                 }
@@ -81,7 +81,6 @@ namespace OSK.Extensions.Object.DeepEquals.Internal.Comparers
                 return false;
             }
 
-            context.SuppressErrorThrow = false;
             return tempList.Count == bSize;
         }
 

--- a/src/OSK.Extensions.Object.DeepEquals/Models/DeepComparisonContext.cs
+++ b/src/OSK.Extensions.Object.DeepEquals/Models/DeepComparisonContext.cs
@@ -23,7 +23,7 @@ namespace OSK.Extensions.Object.DeepEquals.Models
 
         public IDeepComparisonService DeepComparisonService { get; }
 
-        public bool SuppressErrorThrow { get; set; }
+        public bool SuppressErrorThrow { get; internal set; }
 
         #endregion
 
@@ -47,6 +47,17 @@ namespace OSK.Extensions.Object.DeepEquals.Models
         #endregion
 
         #region Helpers
+
+        public DeepComparisonContext CreateScopedContext()
+        {
+            return SuppressErrorThrow 
+                ? this
+                : new DeepComparisonContext(PropertyCache, ObjectCache, CircularReferenceMonitor, DeepComparisonService, 
+                StringComparisonOptions, EnumerableComparisonOptions, PropertyComparisonOptions, ExecutionOptions)
+                {
+                    SuppressErrorThrow = true
+                };
+        }
 
         public bool AreDeepEqual<T, U>(T a, U b)
             => DeepComparisonService.AreDeepEqual(this, a, b);

--- a/src/OSK.Extensions.Object.DeepEquals/ObjectExtensions.cs
+++ b/src/OSK.Extensions.Object.DeepEquals/ObjectExtensions.cs
@@ -5,10 +5,10 @@ namespace OSK.Extensions.Object.DeepEquals
     public static class ObjectExtensions
     {
         /// <summary>
-        /// Performs a typed deep comparison between of two objects of type <see cref="T"/>.
+        /// Performs a typed deep comparison between of two objects/>.
         /// </summary>
         /// <param name="objA">The first object to compare</param>
-        /// <param name="objB">The second object to compare against <see cref="objA"/></param>
+        /// <param name="objB">The second object to compare against</param>
         /// <param name="comparisonOptionOverrides">Allows overriding the globally configured settings in <see cref="DeepEqualsConfiguration"/></param>
         /// <returns>True/False for whether the objects are deeply equal to each other</returns>
         public static bool DeepEquals<T, U>(this T objA, U objB, DeepComparisonOptions comparisonOptionOverrides = null)

--- a/src/OSK.Extensions.Object.DeepEquals/Ports/IDeepEqualityComparer.cs
+++ b/src/OSK.Extensions.Object.DeepEquals/Ports/IDeepEqualityComparer.cs
@@ -22,7 +22,7 @@ namespace OSK.Extensions.Object.DeepEquals.Ports
         /// </summary>
         /// <param name="context">The context of the current deep comparison</param>
         /// <param name="a">The first object to compare</param>
-        /// <param name="b">The second object to compare against <see cref="a"/></param>
+        /// <param name="b">The second object to compare against</param>
         /// <returns>True/False for whether a deeply equals b</returns>
         bool AreDeepEqual(DeepComparisonContext context, object a, object b);
     }

--- a/src/OSK.Extensions.Object.DeepEquals/Ports/IDeepEqualityComparer`1.cs
+++ b/src/OSK.Extensions.Object.DeepEquals/Ports/IDeepEqualityComparer`1.cs
@@ -7,11 +7,11 @@ namespace OSK.Extensions.Object.DeepEquals.Ports
     public interface IDeepEqualityComparer<T>: IDeepEqualityComparer
     {        
         /// <summary>
-        /// Performs a deep comparison on the given objects. Objects passed are expected to comply with the types the comparer <see cref="CanCompare"/>
+        /// Performs a deep comparison on the given objects. Objects passed are expected to comply with the types the <see cref="IDeepEqualityComparer"/>
         /// </summary>
         /// <param name="context">The context of the current deep comparison</param>
         /// <param name="a">The first object to compare</param>
-        /// <param name="b">The second object to compare against <see cref="a"/></param>
+        /// <param name="b">The second object to compare against</param>
         /// <returns>True/False for whether a deeply equals b</returns>
         bool AreDeepEqual(DeepComparisonContext context, T a, T b);
     }


### PR DESCRIPTION
Motivation
----
For better deep equality handling, allow for the creation of scoped contexts to better handle error suppression and other potentially scoped responsbilities

Modifications
----
* Added new Scope method signature for DeepComparisonContext
* Updated XML comments

Result
----
Better error handling on internal comparisons

Fixes #7